### PR TITLE
Readme fix caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ module.exports = function(config) {
 - `name` the BS worker name (optional, defaults to global)
 - `project` the BS worker project name (optional, defaults to global)
 
-> **Note:** you can also pass through any additional options supported by browserstack.  
-See https://www.browserstack.com/automate/capabilities for a full list of supported options.
-
 ### BrowserStack reporter
 
 To report session results back to BrowserStack for display on your BrowserStack dashboard, use the following additional configuration:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module.exports = function(config) {
 - `name` the BS worker name (optional, defaults to global)
 - `project` the BS worker project name (optional, defaults to global)
 
-> **Note:** you can also pass through any additional options supported by browserstack. (EG. `timezone`, `resolution`, etc.)  
+> **Note:** you can also pass through any additional options supported by browserstack.  
 See https://www.browserstack.com/automate/capabilities for a full list of supported options.
 
 ### BrowserStack reporter


### PR DESCRIPTION
The caps supported by the launcher are mentioned exhaustively in the README. Removed the note which stated the reference to extra caps that can be used.